### PR TITLE
Loosen required version of sqlalchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "html5-parser",
     "lxml",
     "psutil~=5.9",
-    "sqlalchemy==2.0.23",
+    "sqlalchemy~=2.0.0",
     "tornado~=6.4",
     # Required due to yapsy 1.12.2 using deprecated modules
     "yapsy @ https://github.com/tibonihoo/yapsy/tarball/master#subdirectory=package",

--- a/wpull/application/main.py
+++ b/wpull/application/main.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 
 from wpull.application.builder import Builder
 from wpull.application.options import AppArgumentParser
@@ -15,10 +16,15 @@ def main(exit=True, use_signals=True):
         application.setup_signal_handlers()
 
     if args.debug_manhole:
-        import manhole
-        import wpull
-        wpull.wpull_builder = builder
-        manhole.install()
+        try:
+            import manhole
+        except ImportError:
+            print("Could not import manhole module.", file=sys.stderr)
+            traceback.print_exc()
+        else:
+            import wpull
+            wpull.wpull_builder = builder
+            manhole.install()
 
     exit_code = application.run_sync()
 


### PR DESCRIPTION
sqlalchemy 2.0.30 was the first version to support 3.13. Loosen the version to use whatever 2.0.x version is deemed most stable by the upstream sqlalchemy organization instead of pinning it to an outdated version of the package.

While here, make `--debug-manhole` work gracefully; the conditional dependency should be installed in this package in a future PR.